### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/git_adr/wiki/service.py
+++ b/src/git_adr/wiki/service.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from git_adr.core import ADR, Config, Git
@@ -76,9 +77,10 @@ class WikiService:
                 return None
 
             remote_url = result.stdout.strip()
-            if "github.com" in remote_url:
+            hostname = urlparse(remote_url).hostname
+            if hostname and hostname.lower() == "github.com":
                 return "github"
-            elif "gitlab" in remote_url.lower():
+            elif hostname and "gitlab" in hostname.lower():
                 return "gitlab"
             return None
         except Exception:


### PR DESCRIPTION
Potential fix for [https://github.com/zircote/git-adr/security/code-scanning/1](https://github.com/zircote/git-adr/security/code-scanning/1)

The correct way to check for valid hostnames in URLs is by parsing the URL and inspecting the `hostname` field directly, rather than using substring matches on the whole URL string. We should use Python's standard library `urllib.parse` to parse the URL and then compare the scheme and/or hostname field. To minimize changes, we will import `urlparse` from `urllib.parse` at the top of the file, and update `detect_platform` to use `urlparse(remote_url).hostname` for reliable detection of GitHub and GitLab URLs.

We'll need to:
- Add `from urllib.parse import urlparse` to the imports.
- Modify `detect_platform` to parse the URL and inspect the hostname (in a case-insensitive fashion).
- Update the check for both GitHub (`hostname == "github.com"`) and GitLab (`"gitlab"` in hostname`).

Only changes to `src/git_adr/wiki/service.py` are needed, within its imports and the `detect_platform` logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
