### PR TITLE
chore: rename homebrew-git-adr to homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
 
             ### Homebrew (macOS)
             ```bash
-            brew tap zircote/git-adr
+            brew tap zircote/tap
             brew install git-adr
             ```
 
@@ -292,7 +292,7 @@ jobs:
       - name: Checkout Homebrew tap
         uses: actions/checkout@v4
         with:
-          repository: zircote/homebrew-git-adr
+          repository: zircote/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
@@ -532,7 +532,7 @@ jobs:
             exit 0
           fi
           # Explicitly set remote URL with token for cross-repo push
-          git remote set-url origin "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/zircote/homebrew-git-adr.git"
+          git remote set-url origin "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/zircote/homebrew-tap.git"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/git-adr.rb

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Or download manually from [GitHub Releases](https://github.com/zircote/git-adr/r
 ### Homebrew (macOS)
 
 ```bash
-brew tap zircote/git-adr
+brew tap zircote/tap
 brew install git-adr
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -115,7 +115,7 @@ The `onedir` mode is used for fast startup (<1 second) vs `onefile` which extrac
 ## Homebrew Formula
 
 The Homebrew formula is maintained at:
-- Repository: `zircote/homebrew-git-adr`
+- Repository: `zircote/homebrew-tap`
 - Formula: `Formula/git-adr.rb`
 
 The `release.yml` workflow automatically updates the formula with:
@@ -129,8 +129,8 @@ If automatic update fails:
 
 ```bash
 # Clone the tap
-git clone https://github.com/zircote/homebrew-git-adr.git
-cd homebrew-git-adr
+git clone https://github.com/zircote/homebrew-tap.git
+cd homebrew-tap
 
 # Get new SHA256
 curl -L https://pypi.org/pypi/git-adr/X.Y.Z/json | jq '.urls[] | select(.packagetype=="sdist") | .digests.sha256'

--- a/uv.lock
+++ b/uv.lock
@@ -466,11 +466,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.20.0"
+version = "3.20.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/23/ce7a1126827cedeb958fc043d61745754464eb56c5937c35bbf2b8e26f34/filelock-3.20.1.tar.gz", hash = "sha256:b8360948b351b80f420878d8516519a2204b07aefcdcfd24912a5d33127f188c", size = 19476, upload-time = "2025-12-15T23:54:28.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7f/a1a97644e39e7316d850784c642093c99df1290a460df4ede27659056834/filelock-3.20.1-py3-none-any.whl", hash = "sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a", size = 16666, upload-time = "2025-12-15T23:54:26.874Z" },
 ]
 
 [[package]]
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "git-adr"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Update all references from `zircote/homebrew-git-adr` to `zircote/homebrew-tap`
- Following standard Homebrew naming convention (`homebrew-tap` → `brew tap user/tap`)
- Also includes filelock 3.20.0 → 3.20.1 upgrade (CVE-2025-68146 fix)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Update brew tap command, checkout repo, and git remote URL |
| `README.md` | Update brew tap command in installation instructions |
| `RELEASING.md` | Update repository references in documentation |
| `uv.lock` | Upgrade filelock for CVE fix |

## Test plan

- [x] `make ci` passes (1769 tests, 94.78% coverage)
- [ ] Verify `brew tap zircote/tap` resolves correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)