### PR TITLE
fix(core): check config flag instead of notes existence in is_initialized()

### DIFF
--- a/src/git_adr/core/notes.py
+++ b/src/git_adr/core/notes.py
@@ -81,12 +81,17 @@ class NotesManager:
     def is_initialized(self) -> bool:
         """Check if git-adr is initialized in this repository.
 
+        Checks the adr.initialized config flag set by `git adr init`.
+        This is more reliable than checking for notes existence because:
+        - A freshly initialized repo has no notes yet
+        - Notes may not be fetched from remote yet
+
         Returns:
             True if initialized, False otherwise.
         """
-        # Check if any notes exist in the ADR namespace
-        notes = self._git.notes_list(self.adr_ref)
-        return len(notes) > 0
+        # Check the initialization marker set by init command
+        initialized = self._git.config_get("adr.initialized")
+        return initialized == "true"
 
     def initialize(self, *, force: bool = False) -> None:
         """Initialize git-adr in the repository.


### PR DESCRIPTION
## Summary
- Fix is_initialized() to check adr.initialized config flag instead of notes existence
- The init() method already sets this flag, but is_initialized() was ignoring it
- This caused false negatives for freshly initialized repos or cloned repos

## Problem
The is_initialized() method was checking if any ADR notes exist, which failed when:
- A freshly initialized repo had no ADRs created yet
- Notes refs had not been fetched from remote
- Notes were manually deleted

## Solution
Now checks the adr.initialized config flag that init() already sets, making initialization detection reliable regardless of notes content.

## Test plan
- [x] All initialization-related tests pass
- [x] Verified fix works in claude-spec repo that was previously broken
- [x] No regressions in existing test suite

Generated with Claude Code