### PR TITLE
fix: skills path should be directory not SKILL.md file

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,20 +1,20 @@
 {
-    "name": "git-adr",
-    "version": "0.2.4",
-    "description": "Comprehensive agent library featuring 115+ specialized Opus 4.5 agents organized by domain",
-    "author": {
-        "name": "zircote",
-        "url": "https://github.com/zircote"
-    },
-    "license": "MIT",
-    "keywords": [
-        "development",
-        "skills",
-        "git",
-        "adr",
-        "git-adr"
-    ],
-    "skills": [
-        "./skills/git-adr/SKILL.md"
-    ]
+  "name": "git-adr",
+  "version": "0.2.4",
+  "description": "Comprehensive agent library featuring 115+ specialized Opus 4.5 agents organized by domain",
+  "author": {
+    "name": "zircote",
+    "url": "https://github.com/zircote"
+  },
+  "license": "MIT",
+  "keywords": [
+    "development",
+    "skills",
+    "git",
+    "adr",
+    "git-adr"
+  ],
+  "skills": [
+    "./skills/git-adr"
+  ]
 }


### PR DESCRIPTION
## Problem

Claude Code's plugin system expects `skills` entries in `plugin.json` to point to **directories** containing a `SKILL.md` file, not to the `SKILL.md` file itself.

The current config causes this error on every plugin load:
```
Plugin (git-adr @ git-adr@zircote): skills load failed from ./skills/git-adr/SKILL.md: path is a file; expected a directory
```

## Fix

Change `./skills/git-adr/SKILL.md` → `./skills/git-adr` in `.claude-plugin/plugin.json`.